### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -12,14 +12,14 @@ jobs:
   autofix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
       - run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4.1.0
         with:
           node-version: 20
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm lint:fix
-      - uses: autofix-ci/action@ff86a557419858bb967097bfc916833f5647fa8c
+      - uses: autofix-ci/action@v1.3.1
         with:
           commit-message: 'chore: apply automated updates'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
       - run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4.1.0
         with:
           node-version: 20
           cache: 'pnpm'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.1.0](https://github.com/actions/setup-node/releases/tag/v4.1.0)** on 2024-10-24T13:51:16Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[autofix-ci/action](https://github.com/autofix-ci/action)** published a new release **[v1.3.1](https://github.com/autofix-ci/action/releases/tag/v1.3.1)** on 2024-07-01T16:34:15Z
